### PR TITLE
block maas cluster deletion

### DIFF
--- a/pkg/util/machine.go
+++ b/pkg/util/machine.go
@@ -1,0 +1,48 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"github.com/spectrocloud/cluster-api-provider-maas/api/v1alpha4"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetMAASMachinesInCluster gets a cluster's MAASMachine resources.
+func GetMAASMachinesInCluster(
+	ctx context.Context,
+	controllerClient client.Client,
+	namespace, clusterName string) ([]*v1alpha4.MaasMachine, error) {
+
+	labels := map[string]string{clusterv1.ClusterLabelName: clusterName}
+	machineList := &v1alpha4.MaasMachineList{}
+
+	if err := controllerClient.List(
+		ctx, machineList,
+		client.InNamespace(namespace),
+		client.MatchingLabels(labels)); err != nil {
+		return nil, err
+	}
+
+	machines := make([]*v1alpha4.MaasMachine, len(machineList.Items))
+	for i := range machineList.Items {
+		machines[i] = &machineList.Items[i]
+	}
+
+	return machines, nil
+}


### PR DESCRIPTION
- [x] test e2e
exact issue was not reproduced but works with deletion e2e
closes: https://github.com/spectrocloud/cluster-api-provider-maas/issues/25