### PR TITLE
update custom image upload docs

### DIFF
--- a/image-generation/README.md
+++ b/image-generation/README.md
@@ -66,6 +66,10 @@ ssh user@<destination-machine>
 
 use <profile-name> profile which has access to create boot-resources or admin
 ```bash
+# maas <= v2.9
+maas <profile-name> boot-resources create name=custom/<image-display-name> architecture=amd64/generic content=<image-filename>
+
+# maas >= v3.0
 size=$(du <image-filename> | awk '{print $1;}')
 sha256checksum=$(sha256sum <image-filename> | awk '{print $1;}')
 maas <profile-name> boot-resources create name=custom/<image-display-name> architecture=amd64/generic sha256=$sha256checksum size=$size content@=<image-filename>

--- a/image-generation/README.md
+++ b/image-generation/README.md
@@ -65,8 +65,10 @@ ssh user@<destination-machine>
 ```
 
 use <profile-name> profile which has access to create boot-resources or admin
-```bash 
-maas <profile-name> boot-resources create name=custom/<image-display-name> architecture=amd64/generic content=<image-filename>
+```bash
+size=$(du <image-filename> | awk '{print $1;}')
+sha256checksum=$(sha256sum <image-filename> | awk '{print $1;}')
+maas <profile-name> boot-resources create name=custom/<image-display-name> architecture=amd64/generic sha256=$sha256checksum size=$size content@=<image-filename>
 ```
 
 ## spectrocloud public images 


### PR DESCRIPTION
The `content` arg needs `@=`, rather than `=`, and `sha256` and `size` are required args using the MAAS CLI from the v3.0 snap.