### PR TITLE
fix API version for metrics-reader ClusterRole

### DIFF
--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader


### PR DESCRIPTION
Fixes the following:
```bash
k apply -f https://github.com/spectrocloud/cluster-api-provider-maas/releases/download/v0.3.0/infrastructure-components.yaml
...
error: unable to recognize "https://github.com/spectrocloud/cluster-api-provider-maas/releases/download/v0.3.0/infrastructure-components.yaml": no matches for kind "ClusterRole" in version "rbac.authorization.k8s.io/v1beta1"
```