### PR TITLE
chore: Make workers replicas configurable

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -123,7 +123,7 @@ metadata:
   name: "${CLUSTER_NAME}-md-0"
 spec:
   clusterName: "${CLUSTER_NAME}"
-  replicas: 1
+  replicas: "${WORKER_MACHINE_COUNT}"
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"


### PR DESCRIPTION
Replicas for worker machines are not configurable, hence when generating using:

```bash
clusterctl generate cluster t-cluster --infrastructure=maas:v0.5.0 --kubernetes-version v1.26.4 --control-plane-machine-count=1 --worker-machine-count=2  > maas-cluster-api.yaml
```

`--worker-machine-count=2` is not reflected in the generated `MachineDeployment` `spec.replicas` as its hardcoded and not templated.