### PR TITLE
PCP-2393: Add custom port support

### DIFF
--- a/pkg/maas/scope/cluster.go
+++ b/pkg/maas/scope/cluster.go
@@ -119,6 +119,11 @@ func (s *ClusterScope) Close() error {
 
 // APIServerPort returns the APIServerPort to use when creating the load balancer.
 func (s *ClusterScope) APIServerPort() int {
+	if infrautil.IsCustomEndpointPresent(s.MaasCluster.GetAnnotations()) {
+		*s.Cluster.Spec.ClusterNetwork.APIServerPort = int32(s.MaasCluster.Spec.ControlPlaneEndpoint.Port)
+		return s.MaasCluster.Spec.ControlPlaneEndpoint.Port
+	}
+
 	if s.Cluster.Spec.ClusterNetwork != nil && s.Cluster.Spec.ClusterNetwork.APIServerPort != nil {
 		return int(*s.Cluster.Spec.ClusterNetwork.APIServerPort)
 	}


### PR DESCRIPTION
- MaasCluster annotation having "spectrocloud.com/custom-dns-provided" with values.
- MaasCluster spec controlPlaneEndpoint with custom endpoint and port.

![Screenshot 2024-01-17 at 9 25 03 AM](https://github.com/spectrocloud/cluster-api-provider-maas/assets/33931378/a4aa1603-6b97-4aae-af4c-704f2ff0b8b1)



Spc Kubernetes pack input for maas custom endpoint.

![Screenshot 2024-01-17 at 9 28 06 AM](https://github.com/spectrocloud/cluster-api-provider-maas/assets/33931378/eb90e5de-e55a-445f-96ea-752929d04da9)
