### PR TITLE
PCP-5221: 'IP already in use' error during Day 2 CP pool operations (Node Repave)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/spectrocloud/cluster-api-provider-maas
 
 go 1.24.2
 
-toolchain go1.24.5
+toolchain go1.24.6
 
 require (
 	github.com/go-logr/logr v1.4.2
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.36.1
 	github.com/pkg/errors v0.9.1
-	github.com/spectrocloud/maas-client-go v0.0.8-beta1
+	github.com/spectrocloud/maas-client-go v0.0.9-beta1
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.31.3
 	k8s.io/apiextensions-apiserver v0.31.3

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
-github.com/spectrocloud/maas-client-go v0.0.8-beta1 h1:PCY6M3M9uXZG8dzoe0jNcMnh4nOhJuZBF2C3vsUXp9A=
-github.com/spectrocloud/maas-client-go v0.0.8-beta1/go.mod h1:CaqAAlh6/xfzc/cDpU8eMG0wqnwx1ODSyXcH86uV7Ww=
+github.com/spectrocloud/maas-client-go v0.0.9-beta1 h1:84xgMpco9nQlz0sIVcSffw9Ifpie7KwrJuPf6uWLuFI=
+github.com/spectrocloud/maas-client-go v0.0.9-beta1/go.mod h1:CaqAAlh6/xfzc/cDpU8eMG0wqnwx1ODSyXcH86uV7Ww=
 github.com/spf13/cast v1.7.0 h1:ntdiHjuueXFgm5nzDRdOS4yfT43P5Fnud6DH50rz/7w=
 github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=


### PR DESCRIPTION
Released IP if it's in user reserved and unknown state