### PR TITLE
PCP-5290: Excessive API calls to MAAS for K8S endpoint DNS record

### DIFF
--- a/pkg/maas/dns/dns_test.go
+++ b/pkg/maas/dns/dns_test.go
@@ -17,6 +17,30 @@ import (
 	"github.com/spectrocloud/maas-client-go/maasclient"
 )
 
+// fakeClientSet minimally satisfies maasclient.ClientSetInterface for tests
+type fakeClientSet struct{ dns maasclient.DNSResources }
+
+func (f *fakeClientSet) BootResources() maasclient.BootResources         { return nil }
+func (f *fakeClientSet) DNSResources() maasclient.DNSResources           { return f.dns }
+func (f *fakeClientSet) Domains() maasclient.Domains                     { return nil }
+func (f *fakeClientSet) IPAddresses() maasclient.IPAddresses             { return nil }
+func (f *fakeClientSet) Tags() maasclient.Tags                           { return nil }
+func (f *fakeClientSet) Machines() maasclient.Machines                   { return nil }
+func (f *fakeClientSet) NetworkInterfaces() maasclient.NetworkInterfaces { return nil }
+func (f *fakeClientSet) RackControllers() maasclient.RackControllers     { return nil }
+func (f *fakeClientSet) ResourcePools() maasclient.ResourcePools         { return nil }
+func (f *fakeClientSet) Spaces() maasclient.Spaces                       { return nil }
+func (f *fakeClientSet) Users() maasclient.Users                         { return nil }
+func (f *fakeClientSet) Zones() maasclient.Zones                         { return nil }
+func (f *fakeClientSet) SSHKeys() maasclient.SSHKeys                     { return nil }
+func (f *fakeClientSet) VMHosts() maasclient.VMHosts                     { return nil }
+
+// fakeIPAddress satisfies maasclient.IPAddress for tests
+type fakeIPAddress struct{ ip net.IP }
+
+func (f *fakeIPAddress) IP() net.IP                                  { return f.ip }
+func (f *fakeIPAddress) InterfaceSet() []maasclient.NetworkInterface { return nil }
+
 func TestDNS(t *testing.T) {
 	log := klogr.New()
 	cluster := &v1beta1.Cluster{
@@ -33,7 +57,6 @@ func TestDNS(t *testing.T) {
 	t.Run("reconcile dns", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		ctrl := gomock.NewController(t)
-		mockClientSetInterface := mockclientset.NewMockClientSetInterface(ctrl)
 		mockDNSResources := mockclientset.NewMockDNSResources(ctrl)
 		mockDNSResourceBuilder := mockclientset.NewMockDNSResourceBuilder(ctrl)
 		s := &Service{
@@ -42,16 +65,14 @@ func TestDNS(t *testing.T) {
 				Cluster:     cluster,
 				MaasCluster: maasCluster,
 			},
-			maasClient: mockClientSetInterface,
+			maasClient: &fakeClientSet{dns: mockDNSResources},
 		}
-		mockClientSetInterface.EXPECT().DNSResources().Return(mockDNSResources)
 		mockDNSResources.EXPECT().List(context.Background(), gomock.Any()).Return(nil, nil)
-		mockClientSetInterface.EXPECT().DNSResources().Return(mockDNSResources)
 		mockDNSResources.EXPECT().Builder().Return(mockDNSResourceBuilder)
 		mockDNSResourceBuilder.EXPECT().WithFQDN(gomock.Any()).Return(mockDNSResourceBuilder)
 		mockDNSResourceBuilder.EXPECT().WithAddressTTL("10").Return(mockDNSResourceBuilder)
 		mockDNSResourceBuilder.EXPECT().WithIPAddresses(nil).Return(mockDNSResourceBuilder)
-		mockDNSResourceBuilder.EXPECT().Create(context.Background())
+		mockDNSResourceBuilder.EXPECT().Create(gomock.Any())
 		err := s.ReconcileDNS()
 
 		g.Expect(err).ToNot(HaveOccurred())
@@ -59,53 +80,24 @@ func TestDNS(t *testing.T) {
 		g.Expect(s.scope.GetDNSName()).To(ContainSubstring(maasCluster.Spec.DNSDomain))
 	})
 
-	t.Run("update dns attachment", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		ctrl := gomock.NewController(t)
-		mockClientSetInterface := mockclientset.NewMockClientSetInterface(ctrl)
-		mockDNSResources := mockclientset.NewMockDNSResources(ctrl)
-		mockDNSResource := mockclientset.NewMockDNSResource(ctrl)
-		mockDNSResourceModifier := mockclientset.NewMockDNSResourceModifier(ctrl)
-		s := &Service{
-			scope: &scope.ClusterScope{
-				Logger:      log,
-				Cluster:     cluster,
-				MaasCluster: maasCluster,
-			},
-			maasClient: mockClientSetInterface,
-		}
-
-		mockClientSetInterface.EXPECT().DNSResources().Return(mockDNSResources)
-		mockDNSResources.EXPECT().List(context.Background(), gomock.Any()).Return([]maasclient.DNSResource{mockDNSResource}, nil)
-		mockDNSResource.EXPECT().Modifier().Return(mockDNSResourceModifier)
-		mockDNSResourceModifier.EXPECT().SetIPAddresses([]string{"1.1.1.1", "8.8.8.8"}).Return(mockDNSResourceModifier)
-		mockDNSResourceModifier.EXPECT().Modify(context.Background()).Return(mockDNSResource, nil)
-
-		err := s.UpdateDNSAttachments([]string{"1.1.1.1", "8.8.8.8"})
-
-		g.Expect(err).ToNot(HaveOccurred())
-	})
-
 	t.Run("machine is registered", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		ctrl := gomock.NewController(t)
-		mockClientSetInterface := mockclientset.NewMockClientSetInterface(ctrl)
 		mockDNSResources := mockclientset.NewMockDNSResources(ctrl)
 		mockDNSResource := mockclientset.NewMockDNSResource(ctrl)
-		mockIPAddress := mockclientset.NewMockIPAddress(ctrl)
 		s := &Service{
 			scope: &scope.ClusterScope{
 				Logger:      log,
 				Cluster:     cluster,
 				MaasCluster: maasCluster,
 			},
-			maasClient: mockClientSetInterface,
+			maasClient: &fakeClientSet{dns: mockDNSResources},
 		}
-		mockClientSetInterface.EXPECT().DNSResources().Return(mockDNSResources)
 		mockDNSResources.EXPECT().List(context.Background(), gomock.Any()).Return([]maasclient.DNSResource{mockDNSResource}, nil)
-		mockDNSResource.EXPECT().IPAddresses().Return([]maasclient.IPAddress{mockIPAddress})
-		mockIPAddress.EXPECT().IP().Return(net.ParseIP("1.1.1.1"))
-		mockIPAddress.EXPECT().IP().Return(net.ParseIP("8.8.8.8"))
+		mockDNSResource.EXPECT().IPAddresses().Return([]maasclient.IPAddress{
+			&fakeIPAddress{ip: net.ParseIP("1.1.1.1")},
+			&fakeIPAddress{ip: net.ParseIP("8.8.8.8")},
+		})
 
 		res, err := s.MachineIsRegisteredWithAPIServerDNS(&infrav1beta1.Machine{
 			Addresses: []v1beta1.MachineAddress{
@@ -122,5 +114,162 @@ func TestDNS(t *testing.T) {
 
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res).To(BeTrue())
+	})
+
+	t.Run("UpdateDNSAttachmentsWithResource - no change", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctrl := gomock.NewController(t)
+		mockDNSResource := mockclientset.NewMockDNSResource(ctrl)
+		s := &Service{
+			scope: &scope.ClusterScope{
+				Logger:      log,
+				Cluster:     cluster,
+				MaasCluster: maasCluster,
+			},
+			maasClient: &fakeClientSet{},
+		}
+
+		// Current IPs match desired IPs -> expect no modify call
+		mockDNSResource.EXPECT().IPAddresses().Return([]maasclient.IPAddress{
+			&fakeIPAddress{ip: net.ParseIP("1.1.1.1")},
+			&fakeIPAddress{ip: net.ParseIP("8.8.8.8")},
+		})
+
+		updated, err := s.UpdateDNSAttachmentsWithResource(mockDNSResource, []string{"8.8.8.8", "1.1.1.1"})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updated).To(BeFalse(), "should not update when IPs match")
+	})
+
+	t.Run("UpdateDNSAttachmentsWithResource - with change", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctrl := gomock.NewController(t)
+		mockDNSResource := mockclientset.NewMockDNSResource(ctrl)
+		mockDNSResourceModifier := mockclientset.NewMockDNSResourceModifier(ctrl)
+		s := &Service{
+			scope: &scope.ClusterScope{
+				Logger:      log,
+				Cluster:     cluster,
+				MaasCluster: maasCluster,
+			},
+			maasClient: &fakeClientSet{},
+		}
+
+		// Current IPs differ from desired -> expect modify call with sorted IPs
+		mockDNSResource.EXPECT().IPAddresses().Return([]maasclient.IPAddress{
+			&fakeIPAddress{ip: net.ParseIP("1.1.1.1")},
+		})
+		mockDNSResource.EXPECT().Modifier().Return(mockDNSResourceModifier)
+		mockDNSResourceModifier.EXPECT().SetIPAddresses([]string{"1.1.1.1", "8.8.8.8"}).Return(mockDNSResourceModifier)
+		mockDNSResourceModifier.EXPECT().Modify(gomock.Any()).Return(mockDNSResource, nil)
+
+		updated, err := s.UpdateDNSAttachmentsWithResource(mockDNSResource, []string{"8.8.8.8", "1.1.1.1"})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updated).To(BeTrue(), "should update when IPs differ")
+	})
+
+	t.Run("UpdateDNSAttachmentsWithResource - empty strings filtered", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctrl := gomock.NewController(t)
+		mockDNSResource := mockclientset.NewMockDNSResource(ctrl)
+		s := &Service{
+			scope: &scope.ClusterScope{
+				Logger:      log,
+				Cluster:     cluster,
+				MaasCluster: maasCluster,
+			},
+			maasClient: &fakeClientSet{},
+		}
+
+		// Empty strings in input should be filtered
+		mockDNSResource.EXPECT().IPAddresses().Return([]maasclient.IPAddress{
+			&fakeIPAddress{ip: net.ParseIP("1.1.1.1")},
+		})
+
+		updated, err := s.UpdateDNSAttachmentsWithResource(mockDNSResource, []string{"", "1.1.1.1", ""})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updated).To(BeFalse(), "empty strings should be filtered and result in no change")
+	})
+
+	t.Run("UpdateDNSAttachmentsWithResource - order insensitive", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctrl := gomock.NewController(t)
+		mockDNSResource := mockclientset.NewMockDNSResource(ctrl)
+		s := &Service{
+			scope: &scope.ClusterScope{
+				Logger:      log,
+				Cluster:     cluster,
+				MaasCluster: maasCluster,
+			},
+			maasClient: &fakeClientSet{},
+		}
+
+		// Different order but same IPs -> no change
+		mockDNSResource.EXPECT().IPAddresses().Return([]maasclient.IPAddress{
+			&fakeIPAddress{ip: net.ParseIP("3.3.3.3")},
+			&fakeIPAddress{ip: net.ParseIP("1.1.1.1")},
+			&fakeIPAddress{ip: net.ParseIP("2.2.2.2")},
+		})
+
+		updated, err := s.UpdateDNSAttachmentsWithResource(mockDNSResource, []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updated).To(BeFalse(), "order should not matter")
+	})
+
+	t.Run("UpdateDNSAttachmentsWithResource - empty to populated", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctrl := gomock.NewController(t)
+		mockDNSResource := mockclientset.NewMockDNSResource(ctrl)
+		mockDNSResourceModifier := mockclientset.NewMockDNSResourceModifier(ctrl)
+		s := &Service{
+			scope: &scope.ClusterScope{
+				Logger:      log,
+				Cluster:     cluster,
+				MaasCluster: maasCluster,
+			},
+			maasClient: &fakeClientSet{},
+		}
+
+		// Empty current -> add IPs
+		mockDNSResource.EXPECT().IPAddresses().Return([]maasclient.IPAddress{})
+		mockDNSResource.EXPECT().Modifier().Return(mockDNSResourceModifier)
+		mockDNSResourceModifier.EXPECT().SetIPAddresses([]string{"1.1.1.1"}).Return(mockDNSResourceModifier)
+		mockDNSResourceModifier.EXPECT().Modify(gomock.Any()).Return(mockDNSResource, nil)
+
+		updated, err := s.UpdateDNSAttachmentsWithResource(mockDNSResource, []string{"1.1.1.1"})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updated).To(BeTrue(), "should update when adding first IP")
+	})
+
+	t.Run("UpdateDNSAttachmentsWithResource - populated to empty", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctrl := gomock.NewController(t)
+		mockDNSResource := mockclientset.NewMockDNSResource(ctrl)
+		mockDNSResourceModifier := mockclientset.NewMockDNSResourceModifier(ctrl)
+		s := &Service{
+			scope: &scope.ClusterScope{
+				Logger:      log,
+				Cluster:     cluster,
+				MaasCluster: maasCluster,
+			},
+			maasClient: &fakeClientSet{},
+		}
+
+		// Remove all IPs
+		mockDNSResource.EXPECT().IPAddresses().Return([]maasclient.IPAddress{
+			&fakeIPAddress{ip: net.ParseIP("1.1.1.1")},
+		})
+		mockDNSResource.EXPECT().Modifier().Return(mockDNSResourceModifier)
+		mockDNSResourceModifier.EXPECT().SetIPAddresses([]string{}).Return(mockDNSResourceModifier)
+		mockDNSResourceModifier.EXPECT().Modify(gomock.Any()).Return(mockDNSResource, nil)
+
+		updated, err := s.UpdateDNSAttachmentsWithResource(mockDNSResource, []string{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updated).To(BeTrue(), "should update when removing all IPs")
 	})
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -17,7 +17,10 @@ limitations under the License.
 package util
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"math"
+	"sort"
 )
 
 // SafeInt64ToInt32 safely converts int64 to int32 with overflow protection
@@ -29,4 +32,21 @@ func SafeInt64ToInt32(value int64) int32 {
 		return math.MinInt32
 	}
 	return int32(value)
+}
+
+// StableHashStringSlice returns a stable, order-insensitive sha256 hash for a slice of strings.
+func StableHashStringSlice(values []string) string {
+	filtered := make([]string, 0, len(values))
+	for _, v := range values {
+		if v != "" {
+			filtered = append(filtered, v)
+		}
+	}
+	sort.Strings(filtered)
+	h := sha256.New()
+	for _, v := range filtered {
+		h.Write([]byte(v))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -1,0 +1,138 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+)
+
+func TestStableHashStringSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input1   []string
+		input2   []string
+		wantSame bool
+	}{
+		{
+			name:     "identical lists same order",
+			input1:   []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			input2:   []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			wantSame: true,
+		},
+		{
+			name:     "identical lists different order",
+			input1:   []string{"3.3.3.3", "1.1.1.1", "2.2.2.2"},
+			input2:   []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"},
+			wantSame: true,
+		},
+		{
+			name:     "different lists",
+			input1:   []string{"1.1.1.1", "2.2.2.2"},
+			input2:   []string{"1.1.1.1", "3.3.3.3"},
+			wantSame: false,
+		},
+		{
+			name:     "empty vs populated",
+			input1:   []string{},
+			input2:   []string{"1.1.1.1"},
+			wantSame: false,
+		},
+		{
+			name:     "both empty",
+			input1:   []string{},
+			input2:   []string{},
+			wantSame: true,
+		},
+		{
+			name:     "with empty strings filtered",
+			input1:   []string{"1.1.1.1", "", "2.2.2.2"},
+			input2:   []string{"2.2.2.2", "1.1.1.1"},
+			wantSame: true,
+		},
+		{
+			name:     "nil vs empty",
+			input1:   nil,
+			input2:   []string{},
+			wantSame: true,
+		},
+		{
+			name:     "duplicates in input",
+			input1:   []string{"1.1.1.1", "1.1.1.1", "2.2.2.2"},
+			input2:   []string{"1.1.1.1", "2.2.2.2", "1.1.1.1"},
+			wantSame: true,
+		},
+		{
+			name:     "single element",
+			input1:   []string{"1.1.1.1"},
+			input2:   []string{"1.1.1.1"},
+			wantSame: true,
+		},
+		{
+			name:     "different single element",
+			input1:   []string{"1.1.1.1"},
+			input2:   []string{"2.2.2.2"},
+			wantSame: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash1 := StableHashStringSlice(tt.input1)
+			hash2 := StableHashStringSlice(tt.input2)
+
+			if tt.wantSame {
+				if hash1 != hash2 {
+					t.Errorf("StableHashStringSlice() hashes should be equal\ngot hash1=%s\ngot hash2=%s", hash1, hash2)
+				}
+			} else {
+				if hash1 == hash2 {
+					t.Errorf("StableHashStringSlice() hashes should be different\ngot hash1=%s\ngot hash2=%s", hash1, hash2)
+				}
+			}
+
+			// Verify hash is stable on repeated calls
+			hash1Again := StableHashStringSlice(tt.input1)
+			if hash1 != hash1Again {
+				t.Errorf("StableHashStringSlice() not stable on repeated calls\nfirst=%s\nsecond=%s", hash1, hash1Again)
+			}
+		})
+	}
+}
+
+func TestStableHashStringSlice_Properties(t *testing.T) {
+	t.Run("hash is non-empty", func(t *testing.T) {
+		hash := StableHashStringSlice([]string{"1.1.1.1"})
+		if hash == "" {
+			t.Error("StableHashStringSlice() returned empty hash")
+		}
+	})
+
+	t.Run("hash is hexadecimal", func(t *testing.T) {
+		hash := StableHashStringSlice([]string{"1.1.1.1"})
+		// SHA256 hex should be 64 characters
+		if len(hash) != 64 {
+			t.Errorf("StableHashStringSlice() hash length = %d, want 64 (SHA256 hex)", len(hash))
+		}
+		// Check it's valid hex
+		for _, c := range hash {
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+				t.Errorf("StableHashStringSlice() hash contains non-hex character: %c", c)
+				break
+			}
+		}
+	})
+}


### PR DESCRIPTION
Eliminated excessive MAAS DNS GET/PUT requests during steady state and long cluster bring-up (e.g., slow CNI) by:
1.  Computed desired IPs without any MAAS calls, then compare hash to the annotation `infrastructure.cluster.x-k8s.io/last-applied-dns-hash`. If equal, return early and skip MAAS entirely. Only if different, fetch the DNS resource once and apply.
2. Refactored DNS service to update via a single helper that compares current/desired sets, sorts IPs, and only calls Modify if different. Expose `UpdateDNSAttachmentsWithResource` for use with the single GET in the cluster controller.
