### PR TITLE
PCP-5485: lxd-initializer pods are crashing with k8s version 1.27.11

### DIFF
--- a/controllers/templates/lxd_initializer_ds.yaml
+++ b/controllers/templates/lxd_initializer_ds.yaml
@@ -36,7 +36,7 @@ spec:
           if ! command -v lxd >/dev/null 2>&1; then
             echo "LXD not present, installing via snap";
             apt-get update;
-            apt-get install -y snapd systemd;
+            apt-get install -y snapd;
             systemctl enable --now snapd.socket;
             snap install lxd --channel=5.0/stable;
           fi


### PR DESCRIPTION
1. Excluded `systemd` installation/update to make it `needrestart` not show up to avoid init container failure.