### PR TITLE
PCP-5890 CAPI Maas Changes to support hypershift

### DIFF
--- a/pkg/maas/machine/machine.go
+++ b/pkg/maas/machine/machine.go
@@ -1053,6 +1053,10 @@ func fromSDKTypeToMachine(m maasclient.Machine) *infrav1beta1.Machine {
 			Type:    clusterv1.MachineExternalIP,
 			Address: v.String(),
 		})
+		machine.Addresses = append(machine.Addresses, clusterv1.MachineAddress{
+			Type:    clusterv1.MachineInternalIP,
+			Address: v.String(),
+		})
 	}
 
 	return machine

--- a/pkg/maas/machine/machine.go
+++ b/pkg/maas/machine/machine.go
@@ -1046,6 +1046,10 @@ func fromSDKTypeToMachine(m maasclient.Machine) *infrav1beta1.Machine {
 			Type:    clusterv1.MachineExternalDNS,
 			Address: m.FQDN(),
 		})
+		machine.Addresses = append(machine.Addresses, clusterv1.MachineAddress{
+			Type:    clusterv1.MachineInternalDNS,
+			Address: m.FQDN(),
+		})
 	}
 
 	for _, v := range m.IPAddresses() {


### PR DESCRIPTION
This PR is to address a couple issues in the hypershift case:

1. Hypershift expects Machine.Status to have InternalIP & InternalDNS addresses. e.g.

Status:                                                                                                                                                                                                                                      
  Addresses:                                                                                                                                                                                                                                 
    Address:  lxd-8x16-02.maas.sc                                                                                                                                                                                                            
    Type:     ExternalDNS                                                                                                                                                                                                                    
    Address:  lxd-8x16-02.maas.sc                                                                                                                                                                                                            
    Type:     InternalDNS                                                                                                                                                                                                                    
    Address:  10.11.130.215                                                                                                                                                                                                                  
    Type:     ExternalIP                                                                                                                                                                                                                     
    Address:  10.11.130.215                                                                                                                                                                                                                  
    Type:     InternalIP                                                                                                                                                                                                                     

2. Hypershift is using FQDN as hostname and we need to change capi maas to use FQDN to match nodes