### PR TITLE
Update security contexts and permissions in MAAS CRDs

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -23,6 +26,14 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
+          capabilities:
+            drop:
+            - ALL
         resources:
           limits:
             cpu: 200m

--- a/spectro/generated/core-base.yaml
+++ b/spectro/generated/core-base.yaml
@@ -272,5 +272,16 @@ spec:
           requests:
             cpu: 200m
             memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: capmaas-manager
       terminationGracePeriodSeconds: 10

--- a/spectro/generated/core-global.yaml
+++ b/spectro/generated/core-global.yaml
@@ -701,10 +701,21 @@ spec:
           requests:
             cpu: 200m
             memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert


### PR DESCRIPTION
Fix container security context for capmaas-controller-manager
  - `allowPrivilegeEscalation: false` — prevents process from gaining more privileges than it started with
  - `runAsNonRoot: true` — enforces the non-root user already set in the Dockerfile (USER 65532)
  - `runAsUser: 65532 / runAsGroup: 65532` — explicitly sets the distroless nonroot uid/gid
  - `capabilities.drop: [ALL]` — drops all Linux capabilities not needed by the controller
  - `seccompProfile.type: RuntimeDefault` (pod-level) — restricts syscalls to the runtime's safe default set

