### PR TITLE
PCP-6452: chore: bump maas-client-go to v0.1.6-beta1 (4.9)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.36.3
 	github.com/pkg/errors v0.9.1
-	github.com/spectrocloud/maas-client-go v0.1.5-beta1
+	github.com/spectrocloud/maas-client-go v0.1.6-beta1
 	github.com/spf13/pflag v1.0.6
 	k8s.io/api v0.32.3
 	k8s.io/apiextensions-apiserver v0.32.3

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
-github.com/spectrocloud/maas-client-go v0.1.5-beta1 h1:OT16996QBW8krHTIctRuO0js+NhB6ODHoQTyiTLxoEU=
-github.com/spectrocloud/maas-client-go v0.1.5-beta1/go.mod h1:LSxLlmaNCmkaldtysbp7Beq/O2wptBb6qE5iKj+Y7Lw=
+github.com/spectrocloud/maas-client-go v0.1.6-beta1 h1:jPAI+ngmVxqrXs1JHyvYpyuOEVNlHE2yKKVZ3RWAX24=
+github.com/spectrocloud/maas-client-go v0.1.6-beta1/go.mod h1:LSxLlmaNCmkaldtysbp7Beq/O2wptBb6qE5iKj+Y7Lw=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=


### PR DESCRIPTION
## Summary
Forward-port of #333 to `spectro-release-4.9`.

Bumps `github.com/spectrocloud/maas-client-go` from `v0.1.5-beta1` to `v0.1.6-beta1`.

`v0.1.6-beta1` contains the multi-tag allocation fix from spectrocloud/maas-client-go#48:
- `WithTags` now uses `params.Add` instead of `params.Set` so all tags are sent as repeated query parameters (`tags=a&tags=b`) instead of only the last tag.
- OAuth signing now uses `v[len(v)-1]` instead of `v[0]` for multi-valued params, matching MAAS Python-dict semantics. Fixes 401 errors when allocating with multiple tags.

The `WithTags` API signature is unchanged, so no caller-side code changes are needed in capmaas. The existing call site (`pkg/maas/machine/machine.go:165` — `allocator.WithTags(mm.Spec.Tags)`) automatically benefits from the fix.

## JIRA
[PCP-6452](https://spectrocloud.atlassian.net/browse/PCP-6452)

## Related
- spectro-master PR (merged): #333
- maas-client-go fix PR: spectrocloud/maas-client-go#48
- maas-client-go release: https://github.com/spectrocloud/maas-client-go/releases/tag/v0.1.6-beta1

## Test plan
- [ ] Cut a CAPMAAS release off `spectro-release-4.9` once merged
- [ ] Update Palette to use the new CAPMAAS image + `maas-client-go v0.1.6-beta1`
- [ ] Verify on a 4.9 cluster that allocating a machine with multiple tags sends all tags and does not 401


[PCP-6452]: https://spectrocloud.atlassian.net/browse/PCP-6452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ