### PR TITLE
chore: bump go directive to 1.25.9 (spectro-release-4.9)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spectrocloud/cluster-api-provider-maas
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
## Description

Bumps the `go` directive in `go.mod` from `1.25.8` to `1.25.9` on the `spectro-release-4.9` branch.

## Changes

- `go.mod`: `go 1.25.8` → `go 1.25.9`

## Verification

- `go mod tidy` runs cleanly (no changes to `go.sum`).
- `make docker-build` succeeds locally.

Co-Authored-By: Oz <oz-agent@warp.dev>