### PR TITLE
PCP-7053 Support for non-ubuntu images

### DIFF
--- a/pkg/maas/machine/machine.go
+++ b/pkg/maas/machine/machine.go
@@ -35,7 +35,22 @@ const (
 	clusterNamespacePrefix    = "cluster-"
 	clusterNamespacePrefixLen = len(clusterNamespacePrefix)
 	hashIDLength              = 8 // Length of hash-based cluster ID
+
+	// customOSSystem is the MAAS osystem for legacy non-prefixed custom images.
+	customOSSystem = "custom"
 )
+
+// splitImage derives the MAAS osystem and distro_series from a boot-resource
+// image name. A prefixed name ("<osystem>/<series>", e.g. "rhel/rocky-92-0-k-1285-0")
+// deploys under that osystem so MAAS handles the OS correctly; a legacy
+// non-prefixed name keeps osystem "custom" (no behavior change for existing
+// Ubuntu images).
+func splitImage(image string) (osystem, distroSeries string) {
+	if os, series, found := strings.Cut(image, "/"); found {
+		return os, series
+	}
+	return customOSSystem, image
+}
 
 type Service struct {
 	scope      *scope.MachineScope
@@ -251,11 +266,12 @@ func (s *Service) DeployMachine(userDataB64 string) (_ *infrav1beta1.Machine, re
 	}
 
 	s.scope.Info("Starting deployment", "system-id", m.SystemID())
+	osystem, distroSeries := splitImage(mm.Spec.Image)
 	deployingM, err := m.Deployer().
 		SetUserData(userDataB64).
-		SetOSSystem("custom").
+		SetOSSystem(osystem).
 		SetEphemeralDeploy(mm.Spec.DeployInMemory).
-		SetDistroSeries(mm.Spec.Image).Deploy(ctx)
+		SetDistroSeries(distroSeries).Deploy(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Unable to deploy machine")
 	}
@@ -281,10 +297,11 @@ func (s *Service) createVMViaMAAS(ctx context.Context, userDataB64 string) (*inf
 		vmName := fmt.Sprintf("vm-%s", machineName)
 		_, _ = m.Modifier().SetHostname(vmName).Update(ctx)
 
+		osystem, distroSeries := splitImage(mm.Spec.Image)
 		deployingM, err := m.Deployer().
 			SetUserData(userDataB64).
-			SetOSSystem("custom").
-			SetDistroSeries(mm.Spec.Image).Deploy(ctx)
+			SetOSSystem(osystem).
+			SetDistroSeries(distroSeries).Deploy(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to deploy existing VM")
 		}

--- a/pkg/maas/machine/splitimage_test.go
+++ b/pkg/maas/machine/splitimage_test.go
@@ -1,0 +1,56 @@
+package machine
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestSplitImage(t *testing.T) {
+	tests := []struct {
+		name         string
+		image        string
+		wantOSSystem string
+		wantDistro   string
+	}{
+		{
+			name:         "prefixed rhel image",
+			image:        "rhel/rocky-92-0-k-1285-0",
+			wantOSSystem: "rhel",
+			wantDistro:   "rocky-92-0-k-1285-0",
+		},
+		{
+			name:         "prefixed suse image",
+			image:        "suse/sles-15-0-k-1304-0",
+			wantOSSystem: "suse",
+			wantDistro:   "sles-15-0-k-1304-0",
+		},
+		{
+			name:         "prefixed ubuntu image",
+			image:        "ubuntu/u-2204-0-k-1329-0",
+			wantOSSystem: "ubuntu",
+			wantDistro:   "u-2204-0-k-1329-0",
+		},
+		{
+			name:         "legacy non-prefixed image stays custom",
+			image:        "u-2204-0-k-1329-0",
+			wantOSSystem: "custom",
+			wantDistro:   "u-2204-0-k-1329-0",
+		},
+		{
+			name:         "empty image stays custom",
+			image:        "",
+			wantOSSystem: "custom",
+			wantDistro:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			osystem, distro := splitImage(tt.image)
+			g.Expect(osystem).To(Equal(tt.wantOSSystem))
+			g.Expect(distro).To(Equal(tt.wantDistro))
+		})
+	}
+}


### PR DESCRIPTION
**Verification:**

After the code changes, CAPMAAS controller correctly picked up the OSSystem and DistroSeries thereby making the MAAS Machine choose the correct image:
<img width="1650" height="639" alt="Screenshot 2026-06-24 at 8 43 10 PM" src="https://github.com/user-attachments/assets/d007eced-eca9-4b6c-ae58-3411000e27e3" />
<img width="1724" height="903" alt="Screenshot 2026-06-24 at 8 41 38 PM" src="https://github.com/user-attachments/assets/f00b9b59-dd1a-4636-af56-a3da0b54ceb5" />
